### PR TITLE
[dmenu-royarg-git] Update from upstream

### DIFF
--- a/dmenu-royarg-git/.SRCINFO
+++ b/dmenu-royarg-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = dmenu-royarg-git
 	pkgdesc = A modified version of the dynamic menu for X, originally designed for dwm.
-	pkgver = 5.2.r13.859b688
+	pkgver = 5.2.r14.dfb64ae
 	pkgrel = 1
 	url = https://github.com/RoyARG02/dmenu
 	arch = i686

--- a/dmenu-royarg-git/PKGBUILD
+++ b/dmenu-royarg-git/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Anurag Roy <anuragr9847@gmail.com>
 _pkgname="dmenu"
 pkgname="$_pkgname-royarg-git"
-pkgver=5.2.r13.859b688
+pkgver=5.2.r14.dfb64ae
 pkgrel=1
 pkgdesc="A modified version of the dynamic menu for X, originally designed for dwm."
 arch=('i686' 'x86_64')


### PR DESCRIPTION
commit dfb64aebca61f0b6a336f79fa2ec12fb204b7b43
Author: Anurag Roy <anuragr9847@gmail.com>
Date:   Fri Jul 21 15:19:07 2023 +0530

    Merge updates from upstream
    
    Squashed commit of the following:
    
    commit 7ab0cb5ef0e19352fc5d64ae0d57a5cf4540acbf
    Author: NRK <nrk@disroot.org>
    Date:   Fri Jul 7 17:00:42 2023 +0600
    
        drw: minor improvement to the nomatches cache
    
        1. use `unsigned int` to store the codepoints, this avoids waste on
           common case where `long` is 64bits. and POSIX guarantees `int` to be
           at least 32bits so there's no risk of truncation.
        2. since switching to `unsigned int` cuts down the memory requirement by
           half, double the cache size from 64 to 128.
        3. instead of a linear search, use a simple hash-table for O(1) lookups.
