### PR TITLE
Update from upstream

### DIFF
--- a/dwm-royarg-git/.SRCINFO
+++ b/dwm-royarg-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = dwm-royarg-git
 	pkgdesc = A modified version of the dynamic window manager for X.
-	pkgver = 6.4.r10.75dcd64
+	pkgver = 6.4.r11.eec38cc
 	pkgrel = 1
 	url = https://github.com/royarg02/dwm
 	arch = i686

--- a/dwm-royarg-git/PKGBUILD
+++ b/dwm-royarg-git/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Anurag Roy <anuragr9847@gmail.com>
 _pkgname="dwm"
 pkgname="$_pkgname-royarg-git"
-pkgver=6.4.r10.75dcd64
+pkgver=6.4.r11.eec38cc
 pkgrel=1
 pkgdesc="A modified version of the dynamic window manager for X."
 arch=('i686' 'x86_64')


### PR DESCRIPTION
commit eec38cc8e5789201add498ce5f364ffdf732ca02
Author: Anurag Roy <anuragr9847@gmail.com>
Date:   Sat Sep 23 12:26:33 2023 +0530

    Merge updates from upstream
    
    Squashed commit of the following:
    
    commit 9f8855343c881bdc01b9fff5b956537ba1106b76
    Author: Hiltjo Posthuma <hiltjo@codemadness.org>
    Date:   Fri Sep 22 15:13:29 2023 +0200
    
        Makefile: remove the options target
    
        The Makefile used to suppress output (by using @), so this target made sense at
        the time.
    
        But the Makefile should be simple and make debugging with less abstractions or
        fancy printing.  The Makefile was made verbose and doesn't hide the build
        output, so remove this target.
    
        Prompted by a question on the mailing list about the options target.
