### PR TITLE
[st-royarg-git] Upstream updates and color fixes

### DIFF
--- a/st-royarg-git/.SRCINFO
+++ b/st-royarg-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = st-royarg-git
 	pkgdesc = A modified version of the simple virtual terminal emulator for X.
-	pkgver = 0.9.r7.2d3a0df
+	pkgver = 0.9.r9.ace7da7
 	pkgrel = 1
 	url = https://github.com/royarg02/st
 	arch = i686

--- a/st-royarg-git/PKGBUILD
+++ b/st-royarg-git/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Anurag Roy <anuragr9847@gmail.com>
 _pkgname="st"
 pkgname="$_pkgname-royarg-git"
-pkgver=0.9.r7.2d3a0df
+pkgver=0.9.r9.ace7da7
 pkgrel=1
 pkgdesc="A modified version of the simple virtual terminal emulator for X."
 arch=('i686' 'x86_64' 'armv7h')


### PR DESCRIPTION
commit ace7da7b23343c57f5259e0b6b2e808be7b4639f
Author: Anurag Roy <anuragr9847@gmail.com>
Date:   Mon Oct 9 15:48:37 2023 +0530

    Merge updates from upstream
    
    Squashed commit of the following:
    
    commit 9846a56bd7fdc86bf788db04bbbcbde7b7eb9952
    Author: Peter Hofmann <scm@uninformativ.de>
    Date:   Sat Oct 7 07:41:02 2023 +0200
    
        Add terminfo entries for bracketed paste mode
    
        Helps Vim (and hopefully others) to discover that this feature exists
        without further user configuration.
    
    commit 559fdc278681c98470749adb59f01cd071720458
    Author: Peter Hofmann <scm@uninformativ.de>
    Date:   Sat Oct 7 07:40:45 2023 +0200
    
        Unhide cursor on RIS (\033c)
    
        It is unclear if it's "required" to do this on RIS, but it's useful when
        calling reset(1) after interactive programs have crashed and garbled up
        the screen.
    
        FWIW, other terminals do it as well (tested with XTerm, VTE, Kitty,
        Alacritty, Linux VT).
    
    commit 8abe4bcb41aa7fda0ae00823f6a20271124150db
    Author: Peter Hofmann <scm@uninformativ.de>
    Date:   Sat Oct 7 07:40:39 2023 +0200
    
        Fix wide glyphs breaking "nowrap" mode
    
        Consider the following example:
    
            printf '\e[?7l';\
            for i in $(seq $(($(tput cols) - 1))); do printf a; done;\
            printf '🙈\n';\
            printf '\e[?7h'
    
        Even though MODE_WRAP has been disabled, the emoji appeared on the next
        line. This patch keeps wide glyphs on the same line and moves them to
        the right-most possible position.
    
    commit 2fc7e532b23e2f820c6b73d352ec7c41fefa45b5
    Author: Peter Hofmann <scm@uninformativ.de>
    Date:   Sat Oct 7 07:40:07 2023 +0200
    
        Don't scroll selection on the other screen
    
        Fixes garbage selections when switching to/from the alternate screen.
    
        How to reproduce:
    
        -   Be in primary screen.
        -   Select something.
        -   Run this (switches to alternate screen, positions the cursor at the
            bottom, triggers selscroll(), and then goes back to primary screen):
    
                tput smcup; tput cup $(tput lines) 0; echo foo; tput rmcup
    
        -   Notice how the (visual) selection now covers a different line.
    
        The reason is that selscroll() calls selnormalize() and that cannot find
        the original range anymore. It's all empty lines now, so it snaps to
        "select the whole line".
    
    commit a6bbc0c96b0a1db804061b0db79101c6b26aec57
    Author: Peter Hofmann <scm@uninformativ.de>
    Date:   Sat Oct 7 07:39:00 2023 +0200
    
        Fix bounds checks of dc.col
    
        dc.collen is the length of dc.col, not the maximum index, hence if x is
        equal to dc.collen, then it's an error.
    
        With config.def.h, the last valid index is 259, so this correctly
        reports "black":
    
            $ printf '\033]4;259;?\e\\'
    
        260 is an invalid index and this reports garbage instead of printing an
        error:
    
            $ printf '\033]4;260;?\e\\'

commit cd0ccaaba38e20e19294a58928da21e4e8d37bab
Author: Anurag Roy <anuragr9847@gmail.com>
Date:   Mon Oct 9 15:00:04 2023 +0530

    Fix foreground,background and cursor color indexes in xresources patch
