### PR TITLE
[slock-royarg-git] Updates from upstream

### DIFF
--- a/slock-royarg-git/.SRCINFO
+++ b/slock-royarg-git/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = slock-royarg-git
 	pkgdesc = A modified version of the simple X display locker.
-	pkgver = 1.5.r0.36cbb5d
-	pkgrel = 2
+	pkgver = 1.5.r1.f402bf5
+	pkgrel = 1
 	url = https://github.com/RoyARG02/slock
 	arch = i686
 	arch = x86_64

--- a/slock-royarg-git/PKGBUILD
+++ b/slock-royarg-git/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Anurag Roy <anuragr9847@gmail.com>
 _pkgname="slock"
 pkgname="$_pkgname-royarg-git"
-pkgver=1.5.r0.36cbb5d
-pkgrel=2
+pkgver=1.5.r1.f402bf5
+pkgrel=1
 pkgdesc="A modified version of the simple X display locker."
 arch=('i686' 'x86_64' 'armv7h')
 url="https://github.com/RoyARG02/$_pkgname"


### PR DESCRIPTION
commit f402bf52abcce0044fa9b4b02e1e9863171aa0b6
Author: Anurag Roy <anuragr9847@gmail.com>
Date:   Mon Oct 9 16:03:44 2023 +0530

    Merge updates from upstream
    
    Squashed commit of the following:
    
    commit a34d8fb4327bbb1afd92e7527c53fcaad547a495
    Author: Hiltjo Posthuma <hiltjo@codemadness.org>
    Date:   Fri Oct 6 11:57:31 2023 +0200
    
        slock.1: use standard wording for options
    
        Remove the OPTIONS section and add an EXIT STATUS section.
    
    commit e8bca65d629a4faa89439c9f0e599efb5a259573
    Author: Hiltjo Posthuma <hiltjo@codemadness.org>
    Date:   Fri Oct 6 11:50:11 2023 +0200
    
        write version to stdout like the man page says
    
    commit ca6f30f621c1195b577ace7a14b9037fab0dab91
    Author: Hiltjo Posthuma <hiltjo@codemadness.org>
    Date:   Fri Oct 6 11:48:40 2023 +0200
    
        slock.1: improve man page
    
        * Fix all lint warnings.
        * Remove "Op Ar arg..." in the description. It looks ugly.
        * No need to set -offset left for .Bd literal.
    
    commit 2fec14c567411b939e717c380d8b4460d462b146
    Author: Hiltjo Posthuma <hiltjo@codemadness.org>
    Date:   Fri Oct 6 11:41:19 2023 +0200
    
        config.mk: no need to set CC
    
    commit 5678764412873baa62e1536f0622d6a7cec62181
    Author: Hiltjo Posthuma <hiltjo@codemadness.org>
    Date:   Fri Oct 6 11:39:40 2023 +0200
    
        Makefile: be verbose and remove options
    
        Some things to improve at some point:
    
        * Respect system/packaging CFLAGS/LDFLAGS (don't hardcode -Os -Wall -pedantic,
          -s, etc).
    
    commit aecfb3f6803bc2e7a5478aeb4f3390cbaaa563c7
    Author: Hiltjo Posthuma <hiltjo@codemadness.org>
    Date:   Fri Oct 6 11:39:31 2023 +0200
    
        update LICENSE
