### PR TITLE
[st-royarg-git] Update from upstream

### DIFF
--- a/st-royarg-git/.SRCINFO
+++ b/st-royarg-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = st-royarg-git
 	pkgdesc = A modified version of the simple virtual terminal emulator for X.
-	pkgver = 0.9.r9.ace7da7
+	pkgver = 0.9.r10.1b77d1e
 	pkgrel = 1
 	url = https://github.com/royarg02/st
 	arch = i686

--- a/st-royarg-git/PKGBUILD
+++ b/st-royarg-git/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Anurag Roy <anuragr9847@gmail.com>
 _pkgname="st"
 pkgname="$_pkgname-royarg-git"
-pkgver=0.9.r9.ace7da7
+pkgver=0.9.r10.1b77d1e
 pkgrel=1
 pkgdesc="A modified version of the simple virtual terminal emulator for X."
 arch=('i686' 'x86_64' 'armv7h')


### PR DESCRIPTION
commit 1b77d1e32c2da10a13ff27db5b2a991cedd42537
Author: Anurag Roy <anuragr9847@gmail.com>
Date:   Wed Feb 21 18:10:42 2024 +0530

    Merge updates from upstream
    
    Squashed commit of the following:
    
    commit a3f7420310be0fd778ef9fe2abf20edc2d8dc81a
    Author: Tim Culverhouse <tim@timculverhouse.com>
    Date:   Sun Feb 18 06:56:49 2024 -0600
    
        csi: check for private marker in 'S' case
    
        The handler for 'S' final character does not check for a private
        marker. This can cause a conflict with a sequence called 'XTSMGRAPHICS'
        which also has an 'S' final character, but uses the private marker '?'.
        Without checking for a private marker, st will perform a scroll up
        operation when XTSMGRAPHICS is seen, which can cause unexpected display
        artifacts.
