### PR TITLE
[st-royarg-git] Update from upstream

### DIFF
--- a/st-royarg-git/.SRCINFO
+++ b/st-royarg-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = st-royarg-git
 	pkgdesc = A modified version of the simple virtual terminal emulator for X.
-	pkgver = 0.9.r10.1b77d1e
+	pkgver = 0.9.r11.33cf52a
 	pkgrel = 1
 	url = https://github.com/royarg02/st
 	arch = i686

--- a/st-royarg-git/PKGBUILD
+++ b/st-royarg-git/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Anurag Roy <anuragr9847@gmail.com>
 _pkgname="st"
 pkgname="$_pkgname-royarg-git"
-pkgver=0.9.r10.1b77d1e
+pkgver=0.9.r11.33cf52a
 pkgrel=1
 pkgdesc="A modified version of the simple virtual terminal emulator for X."
 arch=('i686' 'x86_64' 'armv7h')


### PR DESCRIPTION
commit 33cf52a79db4c2ed1daa2381c79be14a37f703da
Author: Anurag Roy <anuragr9847@gmail.com>
Date:   Mon Feb 26 15:01:28 2024 +0530

    Merge updates from upstream

    Squashed commit of the following:

    commit 7473a8d1a57e5f9aba41b953f4e498c35e1c9dc5
    Author: Quentin Rameau <quinq@fifth.space>
    Date:   Sun Feb 25 01:31:31 2024 +0100

        Fix cursor move with wide glyphs

        st would always move back 1 column,
        even with wide glyhps (using more than a single column).

        The glyph rune is set on its first column,
        and the other ones are to 0,
        so loop until we detect the start of the previous glyph.