### PR TITLE
[st-royarg-git] Update from upstream

### DIFF
--- a/st-royarg-git/.SRCINFO
+++ b/st-royarg-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = st-royarg-git
 	pkgdesc = A modified version of the simple virtual terminal emulator for X.
-	pkgver = 0.9.r11.33cf52a
+	pkgver = 0.9.r12.f96962e
 	pkgrel = 1
 	url = https://github.com/royarg02/st
 	arch = i686

--- a/st-royarg-git/PKGBUILD
+++ b/st-royarg-git/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Anurag Roy <anuragr9847@gmail.com>
 _pkgname="st"
 pkgname="$_pkgname-royarg-git"
-pkgver=0.9.r11.33cf52a
+pkgver=0.9.r12.f96962e
 pkgrel=1
 pkgdesc="A modified version of the simple virtual terminal emulator for X."
 arch=('i686' 'x86_64' 'armv7h')


### PR DESCRIPTION
commit f96962ee37f23ad928cc6c78931c7c5897e26e24
Author: Anurag Roy <anuragr9847@gmail.com>
Date:   Wed Mar 13 16:11:04 2024 +0530

    Merge updates from upstream
    
    Squashed commit of the following:
    
    commit 95f22c53059ccd60ee701ccf2659dacd95e4e89a
    Author: Tommi Hirvola <tommi@hirvola.fi>
    Date:   Mon Mar 4 12:56:30 2024 +0200
    
        set upper limit for REP escape sequence argument
    
        Previously, printf 'L\033[2147483647b' would call tputc('L') 2^31 times,
        making st unresponsive. This commit allows repeating the last character
        at most 65535 times in order to prevent freezing and DoS attacks.
