### PR TITLE
[dwmblocks-royarg-git] Blocks update

### DIFF
--- a/dwmblocks-royarg-git/.SRCINFO
+++ b/dwmblocks-royarg-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = dwmblocks-royarg-git
 	pkgdesc = A modified version of the modular status bar for dwm written in C.
-	pkgver = 1.0.r91.fa7d17c
+	pkgver = 1.0.r93.aa7042c
 	pkgrel = 1
 	url = https://github.com/RoyARG02/dwmblocks
 	install = dwmblocks-royarg-git.install

--- a/dwmblocks-royarg-git/PKGBUILD
+++ b/dwmblocks-royarg-git/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Anurag Roy <anuragr9847@gmail.com>
 _pkgname="dwmblocks"
 pkgname="$_pkgname-royarg-git"
-pkgver=1.0.r91.fa7d17c
+pkgver=1.0.r93.aa7042c
 pkgrel=1
 pkgdesc="A modified version of the modular status bar for dwm written in C."
 arch=('x86_64')


### PR DESCRIPTION
commit aa7042c103987fbb0a06f58130f809105a66c66c
Author: Anurag Roy <anuragr9847@gmail.com>
Date:   Thu Dec 19 20:45:02 2024 +0530

    [blocks] Make now playing module exit early on no player

commit 9f2b655264ee91171000cc939ba18a002d3d42af
Author: Anurag Roy <anuragr9847@gmail.com>
Date:   Thu Dec 19 20:42:06 2024 +0530

    [blocks] Split brightness control from battery module
    
    - Run battery module less often
    - Trigger refresh on adapter plug in through acpi
    - Brightness module only triggerable on signal
