### PR TITLE
[dwmblocks-royarg-git] Now playing module fix

### DIFF
--- a/dwmblocks-royarg-git/.SRCINFO
+++ b/dwmblocks-royarg-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = dwmblocks-royarg-git
 	pkgdesc = A modified version of the modular status bar for dwm written in C.
-	pkgver = 1.0.r93.aa7042c
+	pkgver = 1.0.r94.57214d0
 	pkgrel = 1
 	url = https://github.com/RoyARG02/dwmblocks
 	install = dwmblocks-royarg-git.install

--- a/dwmblocks-royarg-git/PKGBUILD
+++ b/dwmblocks-royarg-git/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Anurag Roy <anuragr9847@gmail.com>
 _pkgname="dwmblocks"
 pkgname="$_pkgname-royarg-git"
-pkgver=1.0.r93.aa7042c
+pkgver=1.0.r94.57214d0
 pkgrel=1
 pkgdesc="A modified version of the modular status bar for dwm written in C."
 arch=('x86_64')


### PR DESCRIPTION
commit 57214d0fa6e4b75c1b4947e7b991945047390644
Author: Anurag Roy <anuragr9847@gmail.com>
Date:   Tue Jan 7 14:28:59 2025 +0530

    [blocks] Fix no title bug in now playing module
    
    Recent change in now playing module removed the title when both artist
    and title can't be retrieved from MPRIS.
