### PR TITLE
Update from upstream

### DIFF
--- a/st-royarg-git/.SRCINFO
+++ b/st-royarg-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = st-royarg-git
 	pkgdesc = A modified version of the simple virtual terminal emulator for X.
-	pkgver = 0.9.2.r5.9afd62c
+	pkgver = 0.9.2.r6.687b50e
 	pkgrel = 1
 	url = https://github.com/royarg02/st
 	arch = i686

--- a/st-royarg-git/PKGBUILD
+++ b/st-royarg-git/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Anurag Roy <anuragr9847@gmail.com>
 _pkgname="st"
 pkgname="$_pkgname-royarg-git"
-pkgver=0.9.2.r5.9afd62c
+pkgver=0.9.2.r6.687b50e
 pkgrel=1
 pkgdesc="A modified version of the simple virtual terminal emulator for X."
 arch=('i686' 'x86_64' 'armv7h')


### PR DESCRIPTION
commit 687b50e223d81c54fed26371b95ba0fe55b09cd5
Author: sasha <sasha.code@posteo.mx>
Date:   Sun Jul 27 05:43:47 2025 +0000

    Eat up "CSI 58" sequences
    
    This is used in the wild by systemd systemctl for example and st
    misinterpreted it as "blink", because it didn't know "58", then saw "5"
    as "blink", and then didn't know "245".
    
    This should print "foo" as normal text:
    
        printf '\e[58:5:245mfoo\n'
        printf '\e[58:2:50:100:200mfoo\n'
