### PR TITLE
[slock-royarg-git] Bump version to 1.6

### DIFF
--- a/slock-royarg-git/.SRCINFO
+++ b/slock-royarg-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = slock-royarg-git
 	pkgdesc = A modified version of the simple X display locker.
-	pkgver = 1.5.r3.0d258d1
+	pkgver = 1.6.r0.4f12c34
 	pkgrel = 1
 	url = https://github.com/RoyARG02/slock
 	arch = i686

--- a/slock-royarg-git/PKGBUILD
+++ b/slock-royarg-git/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Anurag Roy <anuragr9847@gmail.com>
 _pkgname="slock"
 pkgname="$_pkgname-royarg-git"
-pkgver=1.5.r3.0d258d1
+pkgver=1.6.r0.4f12c34
 pkgrel=1
 pkgdesc="A modified version of the simple X display locker."
 arch=('i686' 'x86_64' 'armv7h')

--- a/slock-royarg-git/PKGBUILD
+++ b/slock-royarg-git/PKGBUILD
@@ -15,6 +15,11 @@ conflicts=("$_pkgname" "$_pkgname-git")
 source=("git+$url.git")
 md5sums=('SKIP')
 
+prepare() {
+  cd "$_pkgname"
+  sed -ri 's/((CPP|C|LD)FLAGS) =/\1 +=/g' config.mk
+}
+
 pkgver() {
   cd "$_pkgname"
   git describe --long --tags | sed 's/\([^-]*-\)g/r\1/;s/-/./g'


### PR DESCRIPTION
commit 4f12c347c6bf33e5bf6e96732c290b3ba68c13b1
Author: Hiltjo Posthuma <hiltjo@codemadness.org>
Date:   Sat Aug 9 14:34:37 2025 +0200

    bump version to 1.6
