### PR TITLE
[slock-royarg-git] Update from upstream

### DIFF
--- a/slock-royarg-git/.SRCINFO
+++ b/slock-royarg-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = slock-royarg-git
 	pkgdesc = A modified version of the simple X display locker.
-	pkgver = 1.6.r0.4f12c34
+	pkgver = 1.6.r1.744946d
 	pkgrel = 1
 	url = https://github.com/RoyARG02/slock
 	arch = i686

--- a/slock-royarg-git/PKGBUILD
+++ b/slock-royarg-git/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Anurag Roy <anuragr9847@gmail.com>
 _pkgname="slock"
 pkgname="$_pkgname-royarg-git"
-pkgver=1.6.r0.4f12c34
+pkgver=1.6.r1.744946d
 pkgrel=1
 pkgdesc="A modified version of the simple X display locker."
 arch=('i686' 'x86_64' 'armv7h')


### PR DESCRIPTION
commit 744946d95d2bddfd66d8bd01b88f83f0baace791
Author: Anurag Roy <anuragr9847@gmail.com>
Date:   Sat Aug 16 21:47:03 2025 +0530

    Merge updates from upstream
    
    Squashed commit of the following:
    
    commit 3791a996e230aec59d61faea46634ae4f031e359
    Author: Hiltjo Posthuma <hiltjo@codemadness.org>
    Date:   Sat Aug 16 11:11:27 2025 +0200
    
        add a comment for the ctrl-u clear field combo
    
    commit bf0a5577acbd9ec7c6a577601b97144b205840d7
    Author: Drew Marino <drewmarino25@gmail.com>
    Date:   Fri Aug 15 19:30:19 2025 -0400
    
        Support ^U for clearing password
    
        ^U is a fairly common key combo for clearing fields, this patch adds
        support for it.
