### PR TITLE
[st-royarg-git] Update from upstream

### DIFF
--- a/st-royarg-git/.SRCINFO
+++ b/st-royarg-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = st-royarg-git
 	pkgdesc = A modified version of the simple virtual terminal emulator for X.
-	pkgver = 0.9.3.r2.688f70a
+	pkgver = 0.9.3.r3.04ce0d6
 	pkgrel = 1
 	url = https://st.suckless.org
 	arch = i686

--- a/st-royarg-git/PKGBUILD
+++ b/st-royarg-git/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Anurag Roy <anuragr9847@gmail.com>
 _pkgname="st"
 pkgname="$_pkgname-royarg-git"
-pkgver=0.9.3.r2.688f70a
+pkgver=0.9.3.r3.04ce0d6
 pkgrel=1
 pkgdesc="A modified version of the simple virtual terminal emulator for X."
 arch=('i686' 'x86_64' 'armv7h')


### PR DESCRIPTION
commit 04ce0d643ed17793803e8516f4c9a5b13b93c400
Author: Avro <avro@disroot.org>
Date:   Mon Jun 29 14:26:34 2026 +0000

    fix async-unsafe error paths in sigchld()